### PR TITLE
use fb-data named volume. 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,7 @@ services:
     ports:
       - 8081:8080
     volumes:
-      - /Users/lajp/subbox/docker-compose/filebrowser/data:/data
+      - fb-data:/data
       - /Users/lajp/subbox/docker-compose/filebrowser/config:/config
     environment:
       - FB_BASEURL=/browser
@@ -150,4 +150,9 @@ services:
     volumes:
       - ./db:/pymix/db
       - /Users/lajp/subbox:/subbox
+      - fb-data:/fb-data
       - /var/run/docker.sock:/var/run/docker.sock
+
+volumes:
+  fb-data:
+    driver: local


### PR DESCRIPTION
use fb-data named volume. 
TODO use named volume for other drives and data sharing (pre requisite task is to ensure containers exclusively write to their own drives - e.g. pymix does not write to their drives but instead calls apis)